### PR TITLE
Fix version and refactor

### DIFF
--- a/cluster/testserver-scm-1.rockspec
+++ b/cluster/testserver-scm-1.rockspec
@@ -11,7 +11,7 @@ dependencies = {
     'cartridge == 2.5.1-1',
     'metrics == 0.6.0-1',
     'cartridge-cli-extensions == 1.1.0-1',
-    'crud == 0.6.0-1',
+    'crud == 0.5.0-1',
     'migrations'
 }
 build = {

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ First you need to [install](https://www.tarantool.io/en/download/os-installation
 ```
 git clone git@github.com:ArtDu/spring-petclinic-tarantool.git
 cd spring-petclinic-tarantool/cluster
-tarantoolctl rocks make                                                                 # Install modules
+cartridge build                                                                         # Install modules
 cartridge start -d                                                                      # Start cluster in deamonize mode
 cartridge replicasets setup --bootstrap-vshard                                          # Setup replica sets described in a file replicasets.yml
 curl -X POST http://localhost:8081/migrations/up                                        # Run cluster-wide migrations for your data
@@ -33,10 +33,25 @@ Or you can run it from Maven directly using the Spring Boot Maven plugin. If you
 ./mvnw spring-boot:run
 ```
 
+**Version restrictions**  
+For this example, version restrictions were found:
+
+| rock                   |       version |
+|------------------------|---------------|
+| crud                   | <=0.5.0       |
+
+Also, the `cartridge replicasets setup` command works only when `cartridge-cli >= 2.5.0`.   
+In the future, the example will be improved to work without limiting versions.
+
 ## About tarantool cluster
 
 
-Tarantool is Reliable NoSQL DBMS. This example is run using the [cartridge framework](https://www.tarantool.io/en/cartridge/), which is a handy tarantools orchestrator. Data sharding is performed on the principle of virtual buckets using the [vshard module](https://github.com/tarantool/vshard). Therefore, to begin with, we must install all the necessary modules, they are described in the `testserver-scm-1.rockspec` file using the command `tarantoolctl rocks install`
+Tarantool is Reliable NoSQL DBMS.
+This example is run using the [cartridge framework](https://www.tarantool.io/en/cartridge/),
+which is a handy tarantools orchestrator. 
+Data sharding is performed on the principle of virtual buckets using the [vshard module](https://github.com/tarantool/vshard).
+Therefore, to begin with, we must install all the necessary modules, they are described in the `testserver-scm-1.rockspec`
+file using the command `tarantoolctl rocks make`
 
 ---
 All the code with the cluster logic is in the cluster folder. Using the `cartridge start -d` command, the cartridge framework starts several tarantool instances, the configuration of which is described in the instances.yml file:

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -56,10 +56,9 @@ public class Owner extends Person {
 	private String telephone;
 
 	/*
-	* Implicit join happens on tarantool router
-	* and is then passed using the OwnerRepository.
-	* Space owners does not store pets data,
-	* pets are joined using the owner_id they know.
+	 * Implicit join happens on tarantool router and is then passed using the
+	 * OwnerRepository. Space owners does not store pets data, pets are joined using the
+	 * owner_id they know.
 	 */
 	@Field(name = "pets")
 	private Set<Pet> pets;

--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -41,10 +41,9 @@ public class Pet extends NamedEntity {
 	private LocalDate birthDate;
 
 	/*
-	 * Implicit join happens on tarantool router
-	 * and is then passed using the PetRepo.
-	 * Space only store type_id, not a full tuple of PetType.
-	 * When we return data we replace it.
+	 * Implicit join happens on tarantool router and is then passed using the PetRepo.
+	 * Space only store type_id, not a full tuple of PetType. When we return data we
+	 * replace it.
 	 */
 	@Field(name = "type_id")
 	private PetType type;

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-
 import org.springframework.data.tarantool.repository.Query;
 import org.springframework.data.tarantool.repository.TarantoolRepository;
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetTypeRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetTypeRepository.java
@@ -28,5 +28,4 @@ import java.util.UUID;
  */
 public interface PetTypeRepository extends TarantoolRepository<PetType, UUID> {
 
-
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
@@ -66,8 +66,8 @@ class VisitController {
 	 * @return Pet
 	 */
 	@ModelAttribute("visit")
-	public Visit loadPetWithVisit(@PathVariable("petId") UUID petId, @PathVariable("ownerId") UUID ownerId, Map<String, Object>
-		model) {
+	public Visit loadPetWithVisit(@PathVariable("petId") UUID petId, @PathVariable("ownerId") UUID ownerId,
+			Map<String, Object> model) {
 		Pet pet = this.pets.findPetById(petId);
 		pet.setVisitsInternal(this.visits.findByPetId(petId));
 		model.put("pet", pet);

--- a/src/main/java/org/springframework/samples/petclinic/vet/Specialty.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Specialty.java
@@ -17,7 +17,6 @@ package org.springframework.samples.petclinic.vet;
 
 import java.io.Serializable;
 
-
 import org.springframework.data.tarantool.core.mapping.Tuple;
 import org.springframework.samples.petclinic.model.NamedEntity;
 
@@ -26,7 +25,6 @@ import org.springframework.samples.petclinic.model.NamedEntity;
  *
  * @author Juergen Hoeller
  */
-
 
 @Tuple("specialties")
 public class Specialty extends NamedEntity implements Serializable {

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
@@ -36,10 +36,9 @@ import org.springframework.samples.petclinic.model.Person;
 public class Vet extends Person {
 
 	/*
-	 * Implicit join happens on tarantool router
-	 * and is then passed using the VetRepository.
-	 * Space vets does not store specialties data,
-	 * specialties are joined via vet_specialties space.
+	 * Implicit join happens on tarantool router and is then passed using the
+	 * VetRepository. Space vets does not store specialties data, specialties are joined
+	 * via vet_specialties space.
 	 */
 	@Field(name = "specialties")
 	private Set<Specialty> specialties;

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
@@ -37,8 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Michael Isvy
  */
 
-public interface VetRepository
-		extends TarantoolRepository<Vet, UUID> {
+public interface VetRepository extends TarantoolRepository<Vet, UUID> {
 
 	/**
 	 * Retrieve all <code>Vet</code>s from the data store.

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
@@ -22,22 +22,22 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
- * Simple domain object representing a list of veterinarians. Mostly here to be used for the 'vets' {@link
- * org.springframework.web.servlet.view.xml.MarshallingView}.
+ * Simple domain object representing a list of veterinarians. Mostly here to be used for
+ * the 'vets' {@link org.springframework.web.servlet.view.xml.MarshallingView}.
  *
  * @author Arjen Poutsma
  */
 @XmlRootElement
 public class Vets {
 
-    private List<Vet> vets;
+	private List<Vet> vets;
 
-    @XmlElement
-    public List<Vet> getVetList() {
-        if (vets == null) {
-            vets = new ArrayList<>();
-        }
-        return vets;
-    }
+	@XmlElement
+	public List<Vet> getVetList() {
+		if (vets == null) {
+			vets = new ArrayList<>();
+		}
+		return vets;
+	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/visit/VisitRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/visit/VisitRepository.java
@@ -41,9 +41,10 @@ public interface VisitRepository extends TarantoolRepository<Visit, UUID> {
 	 * @param visit the <code>Visit</code> to save
 	 * @see BaseEntity#isNew
 	 */
-	Visit save(Visit visit)  throws DataAccessException;
+	Visit save(Visit visit) throws DataAccessException;
 
 	// we can't use default findByPetId without annotation yet
 	@Query(function = "find_visits_by_pet_id")
 	List<Visit> findByPetId(UUID petId);
+
 }


### PR DESCRIPTION
The version of the crud has been fixed since the example did not work
due to the fact that apparently an early version of the 0.6.0 crud was
used since the version was used before the release of this version took
place. Also added a description of the limitations of the `crud` and
`cartridge-cli` versions. Fixed style code that forced `spring-javaformat:
apply`.

Closes #2